### PR TITLE
fix: Add stricter validation for content in /config endpoint

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -250,6 +250,13 @@ async function handleRequest(request) {
         }
 
         // 验证 JSON 格式
+        if (typeof configString !== 'string' || configString.trim() === '') {
+            console.error('Config validation error: configString is empty or not a string.');
+            return new Response(t('invalidFormat') + ' The configuration content cannot be empty.', {
+                status: 400,
+                headers: { 'Content-Type': 'text/plain' }
+            });
+        }
         JSON.parse(configString);
 
         await SUBLINK_KV.put(configId, configString, {


### PR DESCRIPTION
Refined error handling for the POST /config endpoint in src/index.js. Added a check to ensure that `configString` (derived from the `content` field of the request JSON) is a non-empty string before attempting `JSON.parse(configString)`.

If `configString` is empty or not a string, a specific 400 error is returned, stating "The configuration content cannot be empty." This prevents `JSON.parse` from throwing an "Unexpected end of JSON input" error for empty content, providing a clearer error message to the client. The existing try-catch for `JSON.parse(configString)` remains to handle other JSON syntax errors in non-empty strings.