### PR TITLE
Okay, I've corrected the data type for 'interval' in the sing-box url…

### DIFF
--- a/src/SingboxConfigBuilder.js
+++ b/src/SingboxConfigBuilder.js
@@ -76,7 +76,7 @@ export class SingboxConfigBuilder extends BaseConfigBuilder {
             tag: t('outboundNames.Auto Select'),
             outbounds: DeepCopy(actualProxyTags),
             url: 'http://www.gstatic.com/generate_204', // Standard test URL
-            interval: 300, // Standard interval
+            interval: "300s", // Standard interval
             lazy: false
         });
 


### PR DESCRIPTION
…test outbound.

I changed the 'interval' field for the 'Auto Select' (urltest) outbound in SingboxConfigBuilder.js from a number (300) to a string ("300s").

This aligns with the sing-box JSON specification, which expects a duration string for this field (e.g., "300s", "5m"). This change should resolve the error "json: cannot unmarshal number into Go value of type string" that was reported when a Go application attempted to parse the generated sing-box configuration.