### PR TITLE
Revert "feat: Refactor proxy group & outbound structures"

### DIFF
--- a/docs/UpdateLogs.md
+++ b/docs/UpdateLogs.md
@@ -7,29 +7,6 @@
 - 更新 `sing-box` 配置生成以符合 `sing-box v1.11.0+` 规范。
   - 将已弃用的“特殊出站”（如 `type: "block"`）替换为“规则操作”（例如，广告拦截规则使用 `action: "reject"`）。
   - 此更改解决了 `sing-box` 可能出现的弃用警告，并确保了未来的兼容性。
-- **重构：增强 Clash 和 Sing-box 的代理组/出站结构**
-  - **Clash 更新详情:**
-    - 引入了受通用高级配置启发的层级式代理组结构。
-    - 添加/修改的关键组:
-      - `🔄 Lazy Config` (fallback: Node Select, Auto Select, Global Direct) - 主要策略路由器。
-      - `🎯 Global Direct` (select: DIRECT)
-      - `🛑 Global Block` (select: REJECT, DIRECT)
-      - `🔰 Node Select` (select: Auto Select, Global Direct, ...节点)
-      - `♻️ 自动选择` (url-test: ...节点)
-      - `🐟 Uncaught Fish` (select: Lazy Config, Node Select, 等) - MATCH 规则的目标。
-    - 特定服务组 (例如 Google, Netflix) 现在提供如 'Lazy Config', 'Node Select' 等选项，以实现更精细的控制。
-    - 'Ad Block' (广告拦截) 规则现在指向 'Global Block' (全局拦截) 组。
-  - **Sing-box 更新详情:**
-    - 将层级式路由理念应用于 Sing-box 出站。
-    - 添加/修改的关键出站:
-      - `Lazy Config` (selector: Node Select, Auto Select, DIRECT) - 主要策略路由器。
-      - `Node Select` (selector: Auto Select, DIRECT, ...节点)
-      - `Auto Select` (urltest: ...节点)
-      - `Uncaught Fish` (selector: Lazy Config, Node Select, 等) - `route.final` 的目标。
-    - 特定服务选择器出站 (例如 Google, Netflix) 现在提供如 'Lazy Config', 'Node Select', 'Auto Select', 'DIRECT', 及特定节点等选项。
-    - 'Ad Block' (广告拦截) 规则继续使用 `action: "reject"`。
-  - **通用说明:**
-    - 这些更改提供了更强大和灵活的路由功能。维护自定义 i18n 文件的用户应添加新的组名翻译键 (例如 `outboundNames.Lazy Config`, `outboundNames.Global Direct`)。
 
 ## 2025-04-30
 


### PR DESCRIPTION
This reverts the changes introduced by the "feat/refactor-proxy-groups" commit. The proxy group generation logic in ClashConfigBuilder.js and SingboxConfigBuilder.js has been restored to its previous, simpler state.

Reason for revert: Your request.

Specific changes reverted:
- Removed the hierarchical proxy group structure (e.g., "Lazy Config", "Global Direct", "Uncaught Fish" groups/outbounds).
- Restored simpler group/outbound creation methods in child builders.
- Clash MATCH rule now targets the original "Fall Back" group.
- Sing-box route.final now targets the original "Fall Back" outbound.
- Removed the corresponding entry from UpdateLogs.md.

Independent fixes (e.g., Sing-box Ad Block using action:"reject", interval format, BaseConfigBuilder compatibility fixes) that occurred after the initial refactor are intended to remain unaffected by this revert.