### PR TITLE
Okay, I've made a fix to remove an unsupported 'lazy' field from the …

### DIFF
--- a/src/SingboxConfigBuilder.js
+++ b/src/SingboxConfigBuilder.js
@@ -63,8 +63,7 @@ export class SingboxConfigBuilder extends BaseConfigBuilder {
             tag: autoSelectTag,
             outbounds: DeepCopy(proxyList),
             url: 'http://www.gstatic.com/generate_204',
-            interval: "300s",
-            lazy: false
+            interval: "300s"
         });
     }
 


### PR DESCRIPTION
…Sing-box urltest outbound.

I removed the 'lazy: false' field from the 'Auto Select' (urltest) outbound definition in `SingboxConfigBuilder.js`.

The 'lazy' field isn't a recognized or standard field for urltest outbounds in the Sing-box JSON configuration specification. Its presence was causing 'json: unknown field "lazy"' errors when your configuration was parsed by Sing-box clients or tools.