### PR TITLE
fix: Correct effective default for certain Sing-box groups

### DIFF
--- a/src/SingboxConfigBuilder.js
+++ b/src/SingboxConfigBuilder.js
@@ -117,9 +117,9 @@ export class SingboxConfigBuilder extends BaseConfigBuilder {
                     type: "selector",
                     tag: groupTag,
                     outbounds: [
-                        "DIRECT",
                         t('outboundNames.Node Select'),
                         t('outboundNames.Auto Select'),
+                        "DIRECT",
                         ...DeepCopy(proxyList)
                     ]
                     // No default field
@@ -162,9 +162,9 @@ export class SingboxConfigBuilder extends BaseConfigBuilder {
             type: "selector",
             tag: fallBackTag,
             outbounds: [
-                "DIRECT",
                 t('outboundNames.Node Select'),
                 t('outboundNames.Auto Select'),
+                "DIRECT",
                 ...DeepCopy(proxyList)
             ]
             // No default field for Fall Back, usually client picks first available.


### PR DESCRIPTION
Reordered the 'outbounds' list for specific Sing-box selector groups (e.g., 'Social Media', 'Gaming', 'Fall Back', and others that should only have 'DIRECT' as an option, not a default).

Previously, "DIRECT" was the first item in their 'outbounds' list, causing some clients to select it as the effective default even when no `default: "DIRECT"` field was set.

The 'outbounds' list for these groups is now:
`[t('outboundNames.Node Select'), t('outboundNames.Auto Select'), "DIRECT", ...proxies]`

This ensures that 'Node Select' or 'Auto Select' are prioritized by clients that pick the first available outbound, while "DIRECT" remains a selectable option. Groups explicitly intended to default to "DIRECT" (e.g., 'Location:CN') retain their `default: "DIRECT"` field and their existing outbound order.